### PR TITLE
Add link to akx/lcm_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Try our 🤗 Hugging Face Demos: [![Hugging Face Spaces](https://img.shields.io/
     <img src="https://user-images.githubusercontent.com/25839884/218347213-c080267f-cbb6-443e-8532-8e1ed9a58ea9.png" width="3%" alt="" /></a> for discussions. Coders are welcome to contribute.
 
 ## News 
+- (🔥New) 2023/10/24 Simple Streamlit UI for local use: [akx/lcm_test](https://github.com/akx/lcm_test)
 - (🔥New) 2023/10/24 We support **SD-Webui** and **ComfyUI** now!! Thanks for [@0xbitches](https://github.com/0xbitches). See the link: [SD-Webui](https://github.com/0xbitches/sd-webui-lcm) and [ComfyUI](https://github.com/0xbitches/ComfyUI-LCM). 
 - (🔥New) 2023/10/23 Running on **Windows/Linux CPU** is also supported! Thanks for [@rupeshs](https://github.com/rupeshs) See the [link](https://github.com/rupeshs/fastsdcpu).
 - (🔥New) 2023/10/22 **Google Colab** is supported now. Thanks for [@camenduru](https://github.com/camenduru/stable-diffusion-webui-colab) See the link: [Colab](https://github.com/camenduru/stable-diffusion-webui-colab/blob/main/special/stable/lcm_dreamshaper_v7_webui_colab.ipynb)


### PR DESCRIPTION
I wrote a small simple Streamlit UI for trying out LCM.

It supports setting a fixed seed, which isn't supported by the upstream pipeline (since the `generator` kwarg that Stable Diffusion pipelines generally use isn't supported).